### PR TITLE
Adding state to Code understanding agent 

### DIFF
--- a/code-understanding/Cargo.toml
+++ b/code-understanding/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 ai-gateway = { path = "../ai-gateway"}
+redis = "0.25.3"
 
 regex = "1.9.1"
 regex-syntax = "0.7.3"
@@ -91,4 +92,4 @@ reqwest = { version = "0.11.18", default-features = false, features = [
 ] }
 env_logger = "0.11.2"
 log = "0.4.21"
-redis = "0.23.0"
+

--- a/code-understanding/Cargo.toml
+++ b/code-understanding/Cargo.toml
@@ -91,3 +91,4 @@ reqwest = { version = "0.11.18", default-features = false, features = [
 ] }
 env_logger = "0.11.2"
 log = "0.4.21"
+redis = "0.23.0"

--- a/code-understanding/src/agent/agent.rs
+++ b/code-understanding/src/agent/agent.rs
@@ -83,7 +83,7 @@ pub struct Agent {
     pub app_state: Arc<AppState>,
     pub exchanges: Vec<Exchange>,
     pub ai_gateway: AIGatewayConfig,
-    pub query_id: uuid::Uuid,
+    pub query_id: String, 
     pub last_function_call_id: Option<String>,
     /// Indicate whether the request was answered.
     ///

--- a/code-understanding/src/agent/agent.rs
+++ b/code-understanding/src/agent/agent.rs
@@ -83,7 +83,7 @@ pub struct Agent {
     pub app_state: Arc<AppState>,
     pub exchanges: Vec<Exchange>,
     pub ai_gateway: AIGatewayConfig,
-    pub query_id: String, 
+    pub query_id: String,
     pub last_function_call_id: Option<String>,
     /// Indicate whether the request was answered.
     ///
@@ -198,21 +198,24 @@ impl Agent {
     }
 
     #[instrument(skip(self))]
-    pub async fn step(&mut self, action: Action) -> Result<Option<Action>> {
+    pub async fn step(&mut self, action: Action, exchange_exists: bool) -> Result<Option<Action>> {
         log::debug!("\ninside step {:?}\n", action);
+        if !exchange_exists {
+            match &action {
+                Action::Query(s) => s.clone(),
 
-        match &action {
-            Action::Query(s) => s.clone(),
+                Action::Answer { paths } => {
+                    self.answer(paths).await.context("answer action failed")?;
+                    return Ok(None);
+                }
 
-            Action::Answer { paths } => {
-                self.answer(paths).await.context("answer action failed")?;
-                return Ok(None);
-            }
-
-            Action::Path { query } => self.path_search(query).await?,
-            Action::Code { query } => self.code_search(query).await?,
-            Action::Proc { query, paths } => self.process_files(query, paths).await?,
-        };
+                Action::Path { query } => self.path_search(query).await?,
+                Action::Code { query } => self.code_search(query).await?,
+                Action::Proc { query, paths } => self.process_files(query, paths).await?,
+            };
+        } else {
+            debug!("exchange exists.");
+        }
 
         let functions = serde_json::from_value::<Vec<Function>>(
             prompts::functions(self.paths().next().is_some()), // Only add proc if there are paths in context
@@ -227,8 +230,14 @@ impl Agent {
         //let trimmed_history = trim_history(history.clone())?;
 
         //log::debug!("trimmed history:\n {:?}", trimmed_history);
-        // call the llm 
-        let llm_output = call_llm(&get_ai_gateway_config(), None, Some(history), Some(functions)).await?;
+        // call the llm
+        let llm_output = call_llm(
+            &get_ai_gateway_config(),
+            None,
+            Some(history),
+            Some(functions),
+        )
+        .await?;
 
         if let Some((function_to_call, id)) = find_first_function_call(&llm_output) {
             log::debug!("{:?} next action", function_to_call);

--- a/code-understanding/src/agent/tools/code.rs
+++ b/code-understanding/src/agent/tools/code.rs
@@ -1,4 +1,5 @@
 use crate::agent::agent::Agent;
+use crate::config::get_redis_url;
 use crate::helpers::symbol_search::symbol_search;
 
 use crate::agent::exchange::{CodeChunk, SearchStep, Update};
@@ -74,7 +75,8 @@ impl Agent {
             query: query.clone(),
             response: response.clone(),
         }))?;
-
+        // save exchanges to redis 
+        self.save_exchanges_to_redis(&get_redis_url())?;
         Ok(response)
     }
 }

--- a/code-understanding/src/agent/tools/path.rs
+++ b/code-understanding/src/agent/tools/path.rs
@@ -6,6 +6,7 @@ use tracing::instrument;
 use crate::agent::agent::Agent;
 
 use crate::agent::exchange::{SearchStep, Update};
+use crate::config::get_redis_url;
 
 impl Agent {
     #[instrument(skip(self))]
@@ -58,6 +59,9 @@ impl Agent {
             query: query.clone(),
             response: response.clone(),
         }))?;
+        // save exchanges to redis 
+        self.save_exchanges_to_redis(&get_redis_url())?;
+        
         let result = "OK";
         Ok(result.to_string())
     }

--- a/code-understanding/src/agent/tools/proc.rs
+++ b/code-understanding/src/agent/tools/proc.rs
@@ -1,6 +1,6 @@
 use crate::{
     agent::agent::Agent,
-    config::{get_ai_gateway_config, get_quickwit_url},
+    config::{get_ai_gateway_config, get_quickwit_url, get_redis_url},
 };
 use anyhow::{anyhow, Context, Result};
 use futures::{stream, StreamExt};
@@ -209,6 +209,8 @@ impl Agent {
             paths,
             response: response.clone(),
         }))?;
+        // save exchanges to redis.
+        self.save_exchanges_to_redis(&get_redis_url());
 
         Ok(response)
     }

--- a/code-understanding/src/config.rs
+++ b/code-understanding/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     pub quickwit_url: String,
     pub semantic_collection_name: String,
     pub search_server_url: String,
+    pub redis_url: String,
     // String containing the yaml configuration of the AI Gateway
     pub ai_gateway_config: String,
 }
@@ -57,6 +58,7 @@ pub fn load_from_env() -> Config {
         env::var("SEMANTIC_COLLECTION_NAME").unwrap_or_else(|_| "documents".to_string());
     let search_server_url =
         env::var("SEARCH_SERVER_URL").unwrap_or_else(|_| "http://localhost:3003".to_string());
+    let redis_url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
 
    Config {
         semantic_url,
@@ -69,6 +71,7 @@ pub fn load_from_env() -> Config {
         quickwit_url,
         semantic_collection_name,
         search_server_url,
+        redis_url,
         ai_gateway_config,
     }
 }
@@ -116,6 +119,10 @@ pub fn get_search_server_url() -> String {
 // New getter for ai_gateway_config
 pub fn get_ai_gateway_config() -> String {
     CONFIG.read().unwrap().ai_gateway_config.clone()
+}
+
+pub fn get_redis_url() -> String {
+    CONFIG.read().unwrap().redis_url.clone()
 }
 
 pub fn clone_config() -> Config {

--- a/code-understanding/src/controller.rs
+++ b/code-understanding/src/controller.rs
@@ -34,13 +34,12 @@ pub async fn handle_retrieve_code(
     let question_id = req.question_id.clone();
 
     // concat task and question id as the unique id to store the exchanges
-    let exchanges_id = format!("{}_{}", task_id, question_id);
+    let query_id = format!("{}_{}", task_id, question_id);
     // check if the exchanges already exist in the redis state
     let mut action = Action::Query(req.query.clone());
-    let id = uuid::Uuid::new_v4();
 
     let mut exchanges = vec![];
-    exchanges.push(Exchange::new(id, req.query.clone()));
+    exchanges.push(Exchange::new(query_id, req.query.clone()));
 
     // get db client from app state
     let ai_gateway_config = get_ai_gateway_config();
@@ -59,7 +58,7 @@ pub async fn handle_retrieve_code(
         app_state: app_state,
         exchanges,
         ai_gateway,
-        query_id: id,
+        query_id: query_id,
         complete: false,
         repo_name: req.repo.clone(),
         last_function_call_id: None,

--- a/code-understanding/src/controller.rs
+++ b/code-understanding/src/controller.rs
@@ -30,6 +30,12 @@ pub async fn handle_retrieve_code(
         ));
     }
 
+    let task_id = req.task_id.clone();
+    let question_id = req.question_id.clone();
+
+    // concat task and question id as the unique id to store the exchanges
+    let exchanges_id = format!("{}_{}", task_id, question_id);
+    // check if the exchanges already exist in the redis state
     let mut action = Action::Query(req.query.clone());
     let id = uuid::Uuid::new_v4();
 

--- a/code-understanding/src/main.rs
+++ b/code-understanding/src/main.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use redis;
 use common::task_graph::{redis::establish_redis_connection, redis_config::get_redis_url};
 use once_cell::sync::Lazy;
 use std::sync::{Once, RwLock};
@@ -16,9 +15,9 @@ mod search;
 use std::sync::Arc;
 
 use core::result::Result::Ok;
+use redis;
 struct AppState {
     db_connection: db_client::DbConnect, // Assuming DbConnection is your database connection type
-    redis_conn: redis::Connection,
 }
 
 // initialize the app state with the configuration and database connection.
@@ -36,7 +35,6 @@ async fn init_state() -> Result<AppState, anyhow::Error> {
         }
     }
 
-    let redis_client = establish_redis_connection(&get_redis_url())?;
 
     // create new db client.
     let db_client = match db_client::DbConnect::new().await {
@@ -48,7 +46,6 @@ async fn init_state() -> Result<AppState, anyhow::Error> {
     };
 
     Ok(AppState {
-        redis_conn: redis_client,
         db_connection: db_client,
     })
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -72,6 +72,6 @@ petgraph = { version = "0.6.3", default-features = false, features = [
 ] }
 expect-test = "1.4.1"
 bincode = "1.3.3"
-redis = "0.23.0"
+redis = "0.25.3"
 uuid = { version = "1.0", features = ["v4"] }
 

--- a/common/src/models.rs
+++ b/common/src/models.rs
@@ -40,6 +40,8 @@ pub struct CodeSpanRequest {
 pub struct CodeUnderstandRequest {
     pub query: String,
     pub repo: String,
+    pub task_id: String,
+    pub question_id: usize, 
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]

--- a/common/src/task_graph/redis.rs
+++ b/common/src/task_graph/redis.rs
@@ -36,7 +36,6 @@ impl TrackProcessV1 {
     Ok(task_process)
 }
 
-
 pub fn establish_redis_connection(url: &str) -> redis::RedisResult<redis::Connection> {
     // Attempt to establish a connection
     let client = redis::Client::open(url)?;


### PR DESCRIPTION
Experimenting with the Code understanding is painful, and also it burns Claude's credits through the roof on each run. This PR allows you to store the exchange state in Redis, where you can replay the past data used for LLM calls and their results for a given task or question id to accelerate experimenting with new ideas without waiting for LLM operations every time and burning credits through the roof. 